### PR TITLE
add Netty LoggingHandler

### DIFF
--- a/src/main/java/me/bw/lab/EchoServer.java
+++ b/src/main/java/me/bw/lab/EchoServer.java
@@ -56,6 +56,7 @@ public class EchoServer {
                     .childHandler(new ChannelInitializer<SocketChannel>() {
                         @Override
                         protected void initChannel(SocketChannel socketChannel) throws Exception {
+                            socketChannel.pipeline().addLast(new io.netty.handler.logging.LoggingHandler());
                             socketChannel.pipeline().addLast(serverHandler);
                         }
                     });


### PR DESCRIPTION
I add LoggingHandler that provided by Netty framework. Debugging the program, you can see LoggingHandler's log message liking "[Dubbo] ... dubbo version: 2.6.1, current host: 192.168.0.211". This is not expected.